### PR TITLE
feat(Proxy): Add feature to supports Proxy configuration

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "sift"
+
+require "irb"
+IRB.start(__FILE__)

--- a/lib/sift.rb
+++ b/lib/sift.rb
@@ -66,6 +66,11 @@ module Sift
     attr_accessor :account_id
   end
 
+  # Proxy Configuration
+  class << self
+    attr_accessor :proxy_uri, :proxy_cert_file
+  end
+
   # Sets the Output logger to use within the client. This can be left uninitializaed
   # but is useful for debugging.
   def self.logger=(logger)

--- a/lib/sift/client.rb
+++ b/lib/sift/client.rb
@@ -317,12 +317,12 @@ module Sift
       raise("user_id must be a non-empty string") if (!user_id.is_a? String) || user_id.to_s.empty?
       raise("Bad api_key parameter") if api_key.empty?
 
-      query = {}
-      query["api_key"] = api_key
+      query = { "api_key": api_key }
       query["abuse_types"] = abuse_types.join(",") if abuse_types
-      # TODO: Apply timeout option
 
-      response = connection.get(Sift.score_api_path(user_id, version), query)
+      response = connection.get(Sift.score_api_path(user_id, version), query) do |req|
+        req.options.timeout = timeout unless timeout.nil?
+      end
       Response.new(response.body, response.status)
     end
 
@@ -368,11 +368,12 @@ module Sift
       raise("user_id must be a non-empty string") if (!user_id.is_a? String) || user_id.to_s.empty?
       raise("Bad api_key parameter") if api_key.empty?
 
-      query = {}
-      query["api_key"] = api_key
+      query = { "api_key": api_key }
       query["abuse_types"] = abuse_types.join(",") if abuse_types
 
-      response = connection.get(Sift.user_score_api_path(user_id, @version), query)
+      response = connection.get(Sift.user_score_api_path(user_id, @version), query) do |req|
+        req.options.timeout = timeout unless timeout.nil?
+      end
       Response.new(response.body, response.status)
     end
 
@@ -418,6 +419,7 @@ module Sift
       query["abuse_types"] = abuse_types.join(",") if abuse_types
 
       response = connection.post(Sift.user_score_api_path(user_id, @version)) do |req|
+        req.options.timeout = timeout unless timeout.nil?
         req.params = query
       end
       Response.new(response.body, response.status)
@@ -507,10 +509,12 @@ module Sift
 
       raise("user_id must be a non-empty string") if (!user_id.is_a? String) || user_id.to_s.empty?
 
-      query = { api_key: api_key }
+      query = { "api_key": api_key }
       query[:abuse_type] = abuse_type if abuse_type
 
-      response = connection.delete(Sift.users_label_api_path(user_id, version), query)
+      response = connection.delete(Sift.users_label_api_path(user_id, version), query) do |req|
+        req.options.timeout = timeout unless timeout.nil?
+      end
       Response.new(response.body, response.status)
     end
 

--- a/sift.gemspec
+++ b/sift.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "webmock", ">= 1.16.0", "< 2"
 
   # Gems that must be intalled for sift to work
+  s.add_dependency "faraday", [">= 0.17.3", "< 3.0"]
   s.add_dependency "httparty", ">= 0.11.0"
   s.add_dependency "multi_json", ">= 1.0"
 


### PR DESCRIPTION
Usage:

```ruby
require "sift"
require "faraday/typhoeus"

# Sift Authentication
Sift.api_key = "api_key_here"
Sift.account_id = "account_id_here"

# Proxy
# This can be any proxy, not only VGS Proxy
Sift.proxy_uri = "https://username:password@vault.domain:port"
Sift.proxy_cert_file = File.join(File.dirname(__FILE__), 'certs', 'sandbox.pem')

# enable typhoeus for the adapter to support proxy
options = {}
options[:connection_build] = lambda { |builder|
  builder.request(:url_encoded)
  builder.adapter(:typhoeus)
}

# initalize new client
@client = Sift::Client.new(options)

# send event
# enable_proxy must be true if want to activate the proxy
@response = @client.track("$update_account", {
  "$user_id" => "user_id_here"
}, { return_score: true }, true)
```

There are a lot of failed tests, I think will skip them for now and will focus on the supporting proxy to send events